### PR TITLE
More robust env handling

### DIFF
--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import argparse
 import docker_hostdns.console as dconsole
 
 app_args = sys.argv[1:]
@@ -13,7 +14,47 @@ app_args = sys.argv[1:]
 if len(sys.argv) > 1 and app_args[0][0] != "-":
 	os.execvp(app_args[0], app_args)
 
-pre_args = []
+env_conf = {}
+
+envs = [
+	(
+		{
+			"DNS_ZONE": "zone",
+			"DNS_KEY_NAME": "dns_key_name",
+			"NAME": "name",
+			"DNS_SERVER": "dns_server"
+		},
+		str
+	),
+	(
+		{
+			"SYSLOG": "syslog",
+			"CLEAR_ON_EXIT": "clear_on_exit"
+		},
+		lambda x: x.lower() in ["true", "yes", "1", "y"]
+	),
+	(
+		{
+			"NETWORK": "network"
+		},
+		lambda x: [y.strip() for y in x.split(',')]
+	),
+	(
+		{
+			"VERBOSITY": "verbose"
+		},
+		int
+	)
+]
+
+for env_list, value_normalizer in envs:
+	for env_name, conf_key in env_list.items():
+		value = os.environ.get(env_name)
+		if value:
+			try:
+				env_conf[conf_key] = value_normalizer(value)
+			except Exception as e:
+				raise Exception("Error on parsing %s: %r" % (env_name, value)) from e
 
 key_secret = os.environ.get("DNS_KEY_SECRET")
 if key_secret is None:
@@ -23,47 +64,8 @@ if key_secret is None:
 			key_secret = f.read()
 
 if key_secret:
-	pre_args.extend(["--dns-key-secret", key_secret])
+	env_conf["dns_key_secret"] = key_secret
 
-dns_key_name = os.environ.get("DNS_KEY_NAME")
-if dns_key_name:
-	pre_args.extend(["--dns-key-name", dns_key_name])
-
-dns_zone = os.environ.get("DNS_ZONE")
-if dns_zone:
-        pre_args.extend(["--zone", dns_zone])
-
-dns_server = os.environ.get("DNS_SERVER")
-if dns_server:
-        pre_args.extend(["--dns-server", dns_server])
-
-instance_name = os.environ.get("NAME")
-if instance_name:
-	pre_args.extend(["--name", instance_name])
-
-network = os.environ.get("NETWORK")
-if network:
-        net_list = [x.strip() for x in network.split(',')]
-        for network in net_list:
-                pre_args.extend(["--network", network])
-
-verbosity = os.environ.get("VERBOSITY")
-if verbosity:
-        try:
-                verb_int = int(verbosity)
-        except ValueError:
-                verb_int = None
-
-        if verb_int:
-                for count in range(min(verb_int, 3)):
-                        pre_args.extend(["-v"])
-
-syslog = os.environ.get("SYSLOG")
-if syslog and syslog.lower() in ["true", "yes"]:
-	pre_args.extend(["--syslog"])
-
-clear_on_exit = os.environ.get("CLEAR_ON_EXIT")
-if clear_on_exit and clear_on_exit.lower() in ["true", "yes"]:
-	pre_args.extend(["--clear-on-exit"])
-
-dconsole.execute([sys.argv[0]] + pre_args + app_args)
+conf = vars(dconsole.parse_commandline([sys.argv[0]] + app_args))
+conf.update(env_conf)
+dconsole.execute_with_configuration(argparse.Namespace(**conf))


### PR DESCRIPTION
PR for PR :)

If adding all the options as env params I think it is better to have some kind of loop to do than as logic for handling it is repeating.
One difference from your code is that when env is given it should replace command line parameter (eg. ``NETWORK=a,s,d ./app --network q`` => ``network=["a","s","d"]``).

Can you check if it does work in all your cases?
